### PR TITLE
set vendor security patch level

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -113,6 +113,9 @@ persist.timed.enable=true
 # UART
 sys.uart.enable=0
 
+# Vendor security patch level
+ro.lineage.build.vendor_security_patch=2018-03-05
+
 # WiFi
 ro.disableWifiApFirmwareReload=true
 wifi.interface=wlan0


### PR DESCRIPTION
* This is needed for Trust, as we don't have a Vendor image that sets a valid vendor security patch level.
* Taken from stock